### PR TITLE
Fix docker run command line - exposing the port -p 8080:8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@
     
     docker images
     
-    docker run IMAGE-ID
+    docker run -p 8080:8080 IMAGE-ID
+	
+    or
+
+    docker run -p 8080:8080 -t IMAGE-TAG		
 
 # demo-rafa
   A small web service to calculate if a card is usury or not.


### PR DESCRIPTION
I noted you are inverting the order in the command line

instead of using:

```docker run image-id -p 8080:8080 --net host```

use:

```docker run -p 8080:8080  image-id```

or
 
```docker run -p 8080:8080  -t  image-tag```

note: It could be related to issue #2

